### PR TITLE
feat(app): adding kill on delete

### DIFF
--- a/cmd/reloader/config_map_test.go
+++ b/cmd/reloader/config_map_test.go
@@ -226,3 +226,215 @@ func Test_OnConfigMapUpdate(t *testing.T) {
 		}
 	})
 }
+
+func Test_OnConfigMapDelete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		logger := slog.New(slog.DiscardHandler)
+		bucket := cache.NewFixedHashBucket(1)
+
+		pods := []*corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "default",
+					Labels:    map[string]string{"reloader/configmap": "in-bucket"},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+					Labels:    map[string]string{"reloader/configmap": "in-bucket"},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod3",
+					Namespace: "default",
+					Labels:    map[string]string{"reloader/configmap": "not-in-bucket"},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+		}
+
+		kubeClient := fake.NewClientset()
+		for _, pod := range pods {
+			_, err := kubeClient.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+			require.NoError(t, err)
+		}
+
+		informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+		podLister := informerFactory.Core().V1().Pods().Lister()
+		informerFactory.Start(ctx.Done())
+		informerFactory.WaitForCacheSync(ctx.Done())
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "in-bucket",
+				Namespace: "default",
+			},
+			Data: map[string]string{"key": "value"},
+		}
+
+		_, err := kubeClient.CoreV1().ConfigMaps("default").Create(ctx, cm, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		handler := onConfigMapDelete(ctx, logger, bucket, kubeClient, podLister)
+		handler(cm)
+
+		// Check that the pods were killed
+		for _, pod := range pods[:2] {
+			_, err = kubeClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+			require.EqualError(t, err, fmt.Sprintf("pods %q not found", pod.Name))
+		}
+
+		// Check that the pod that was not in the bucket was not killed
+		_, err = kubeClient.CoreV1().Pods(pods[2].Namespace).Get(ctx, pods[2].Name, metav1.GetOptions{})
+		require.NoError(t, err)
+	})
+
+	t.Run("not-configmap", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		logger := slog.New(slog.DiscardHandler)
+		bucket := cache.NewFixedHashBucket(1)
+
+		pods := []*corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "default",
+					Labels:    map[string]string{"reloader/configmap": "in-bucket"},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+					Labels:    map[string]string{"reloader/configmap": "in-bucket"},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod3",
+					Namespace: "default",
+					Labels:    map[string]string{"reloader/configmap": "not-in-bucket"},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+		}
+
+		kubeClient := fake.NewClientset()
+		for _, pod := range pods {
+			_, err := kubeClient.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+			require.NoError(t, err)
+		}
+
+		informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+		podLister := informerFactory.Core().V1().Pods().Lister()
+		informerFactory.Start(ctx.Done())
+		informerFactory.WaitForCacheSync(ctx.Done())
+
+		handler := onConfigMapDelete(ctx, logger, bucket, kubeClient, podLister)
+		handler(testablePod(t))
+
+		for _, pod := range pods {
+			p, err := kubeClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, corev1.PodRunning, p.Status.Phase)
+		}
+	})
+
+	t.Run("not-in-bucket", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		logger := slog.New(slog.DiscardHandler)
+		bucket := cache.NewFixedHashBucket(2)
+		bucket.Advance() // Advance the bucket to ensure the configmap is not in it
+
+		pods := []*corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "default",
+					Labels:    map[string]string{"reloader/configmap": "in-bucket"},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+					Labels:    map[string]string{"reloader/configmap": "in-bucket"},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod3",
+					Namespace: "default",
+					Labels:    map[string]string{"reloader/configmap": "not-in-bucket"},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+		}
+
+		kubeClient := fake.NewClientset()
+		for _, pod := range pods {
+			_, err := kubeClient.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+			require.NoError(t, err)
+		}
+
+		informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+		podLister := informerFactory.Core().V1().Pods().Lister()
+		informerFactory.Start(ctx.Done())
+		informerFactory.WaitForCacheSync(ctx.Done())
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "in-bucket",
+				Namespace: "default",
+			},
+			Data: map[string]string{"key": "value"},
+		}
+
+		handler := onConfigMapDelete(ctx, logger, bucket, kubeClient, podLister)
+
+		handler(cm)
+
+		for _, pod := range pods {
+			p, err := kubeClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, corev1.PodRunning, p.Status.Phase)
+		}
+	})
+}

--- a/cmd/reloader/k8s.go
+++ b/cmd/reloader/k8s.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// killPods deletes the given pods from the cluster. It returns an error if any of the
 func killPods(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,

--- a/cmd/reloader/main.go
+++ b/cmd/reloader/main.go
@@ -16,7 +16,10 @@ const (
 
 type (
 	// AppConfig is the configuration for the app.
-	AppConfig struct{}
+	AppConfig struct {
+		// KillOnDelete is the flag to kill the pods on dependent deletion.
+		KillOnDelete bool `env:"KILL_ON_DELETE" envDefault:"false"`
+	}
 
 	// App is the main application struct.
 	App struct {
@@ -28,6 +31,7 @@ type (
 	}
 )
 
+// NewApp creates a new application instance.
 func NewApp(l *slog.Logger) (*App, error) {
 	base, err := web.NewApp(l)
 	if err != nil {
@@ -45,6 +49,7 @@ func NewApp(l *slog.Logger) (*App, error) {
 	}, nil
 }
 
+// Start starts the application.
 func (a *App) Start() error {
 	if err := a.base.Start(
 		web.WithInClusterKubeClient(),
@@ -59,10 +64,12 @@ func (a *App) Start() error {
 	return nil
 }
 
+// WaitForEnd waits for the application to end.
 func (a *App) WaitForEnd() {
 	a.base.WaitForEnd(a.Shutdown)
 }
 
+// Shutdown shuts down the application.
 func (a *App) Shutdown() {
 	a.base.Shutdown()
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces functionality to handle the deletion of ConfigMaps and Secrets in the application. It adds support for killing dependent pods when their associated ConfigMaps or Secrets are deleted, controlled by a new configuration flag. The changes also include corresponding test cases to ensure correctness.

### Core Functionality Enhancements:

* **ConfigMap Deletion Handling**:
  - Added the `onConfigMapDelete` function to handle ConfigMap deletions. This function identifies pods dependent on the deleted ConfigMap and deletes them if they are in the appropriate hash bucket.
  - Updated the `watchConfigMaps` method to include the new deletion handler.

* **Secret Deletion Handling**:
  - Added the `onSecretDelete` function to handle Secret deletions similarly to the ConfigMap deletion logic.
  - Modified the `watchSecrets` method to conditionally include the deletion handler based on the new `KillOnDelete` configuration flag.

### Configuration Changes:

* Introduced a new `KillOnDelete` flag in the `AppConfig` struct. This flag is set via an environment variable and determines whether pods should be killed on ConfigMap or Secret deletion.

### Testing Enhancements:

* Added a comprehensive test suite for the `onConfigMapDelete` function, covering scenarios like successful deletion, handling non-ConfigMap objects, and ignoring ConfigMaps not in the bucket.

### Utility Function:

* Added the `killPods` function to encapsulate the logic for deleting pods from the cluster. This function is reused in both ConfigMap and Secret deletion handlers.