### PR TITLE
feat(app): adding pod lister init

### DIFF
--- a/cmd/reloader/main.go
+++ b/cmd/reloader/main.go
@@ -54,6 +54,7 @@ func (a *App) Start() error {
 	if err := a.base.Start(
 		web.WithInClusterKubeClient(),
 		web.WithServiceEndpointHashBucket(appName),
+		web.WithKubernetesPodInformer(),
 		web.WithKubernetesConfigMapInformer(),
 		web.WithKubernetesSecretInformer(),
 		web.WithIndefiniteAsyncTask("configmaps-reload", a.watchConfigMaps),


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a small but significant change to the `Start` method in `cmd/reloader/main.go`. The change introduces a new Kubernetes Pod Informer to the application's startup configuration.

* [`cmd/reloader/main.go`](diffhunk://#diff-6fba5890e44a8cffe60876a84a61cc4433852e572fbaf4e031bb036e133d7913R57): Added `web.WithKubernetesPodInformer()` to the `Start` method to enable the application to monitor Kubernetes Pod events.