### PR TITLE
feat(app): kill on delete config maps

### DIFF
--- a/cmd/reloader/config_map.go
+++ b/cmd/reloader/config_map.go
@@ -28,6 +28,16 @@ func (a *App) watchConfigMaps(ctx context.Context) {
 		),
 	}
 
+	if a.config.KillOnDelete {
+		handler.DeleteFunc = onConfigMapDelete(
+			ctx,
+			logging.LoggerWithComponent(a.base.Logger(), "configmaps"),
+			a.base.ServiceEndpointHashBucket(),
+			a.base.KubeClient(),
+			a.base.PodLister(),
+		)
+	}
+
 	_, err := informer.AddEventHandler(handler)
 	if err != nil {
 		a.base.Logger().Error("failed to add event handler", slog.String(logging.KeyError, err.Error()))


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces a conditional handler for the deletion of ConfigMaps in the `watchConfigMaps` function, enhancing the application's behavior based on configuration settings.

Enhancement to ConfigMap handling:

* [`cmd/reloader/config_map.go`](diffhunk://#diff-42a5d3de503c113a4cd45d29ad2c9568d24957338c7c3a76dfaa7695363ee0a4R31-R40): Added a `DeleteFunc` to the event handler in `watchConfigMaps` if the `KillOnDelete` configuration is enabled. This ensures that specific actions are triggered when a ConfigMap is deleted, improving the application's responsiveness to configuration changes.